### PR TITLE
lodash library not imported anymore in Sequelize new versions

### DIFF
--- a/lib/sequelize-mocking-jasmine.js
+++ b/lib/sequelize-mocking-jasmine.js
@@ -11,8 +11,8 @@
 'use strict';
 
 // Imports
+const _ = require('lodash');
 const Sequelize = require('sequelize');
-const _ = Sequelize.Utils._;
 const SequelizeMocking = require('./sequelize-mocking');
 
 /**

--- a/lib/sequelize-mocking-mocha.js
+++ b/lib/sequelize-mocking-mocha.js
@@ -29,9 +29,10 @@ module.exports = function (originalSequelize, fixtureFilePath, options) {
         let mockedSequelize = null;
 
         beforeEach(function (done) {
-            let createFunc = _.partialRight(fixtureFilePath ? SequelizeMocking.createAndLoadFixtureFile : SequelizeMocking.create, options);
 
-            createFunc(originalSequelize, fixtureFilePath)
+            let createFunc = fixtureFilePath ? SequelizeMocking.createAndLoadFixtureFile : SequelizeMocking.create;
+
+            createFunc(originalSequelize, fixtureFilePath, options)
                 .then(function (sequelizeInstance) {
                     mockedSequelize = sequelizeInstance;
                     done();

--- a/lib/sequelize-mocking-mocha.js
+++ b/lib/sequelize-mocking-mocha.js
@@ -11,8 +11,8 @@
 'use strict';
 
 // Imports
+const _ = require('lodash');
 const Sequelize = require('sequelize');
-const _ = Sequelize.Utils._;
 const SequelizeMocking = require('./sequelize-mocking');
 
 /**

--- a/lib/sequelize-mocking-tape.js
+++ b/lib/sequelize-mocking-tape.js
@@ -11,10 +11,10 @@
 'use strict';
 
 // Imports
+const _ = require('lodash');
 const test = require('tape');
 
 const Sequelize = require('sequelize');
-const _ = Sequelize.Utils._;
 const SequelizeMocking = require('./sequelize-mocking');
 
 /**

--- a/lib/sequelize-mocking.js
+++ b/lib/sequelize-mocking.js
@@ -11,7 +11,6 @@
 'use strict';
 
 // Imports
-const _ = require('lodash');
 const Sequelize = require('sequelize');
 const sequelizeFixtures = require('sequelize-fixtures');
 
@@ -33,20 +32,21 @@ const SQLITE_SEQUELIZE_OPTIONS = {
  * Sequelize mocking service
  */
 class SequelizeMocking {
+
+    static noop() {}
+
     /**
      * @param {Sequelize} sequelizeInstance
      * @param {SequelizeMockingOptions} [options]
      * @returns {Sequelize} Mocked Sequelize object
      */
     static adaptSequelizeOptions(sequelizeInstance, options) {
-        let optionsExtended = _.merge(
+        return Object.assign(
             { },
             sequelizeInstance.options,
             SQLITE_SEQUELIZE_OPTIONS,
             { 'logging': options && !options.logging ? false : console.log }
         );
-
-        return optionsExtended;
     }
 
     /**
@@ -59,8 +59,8 @@ class SequelizeMocking {
         }
 
         let newModel = TempModel.init(
-            _.merge({ }, model.attributes),
-            _.merge({ }, model.options, { 'sequelize': sequelizeInstance, 'modelName': model.name })
+            Object.assign({ }, model.attributes),
+            Object.assign({ }, model.options, { 'sequelize': sequelizeInstance, 'modelName': model.name })
         );
         return newModel;
     }
@@ -160,10 +160,10 @@ class SequelizeMocking {
         let logging = !options || options.logging;
         let transformFixtureDataFn = !options || options.transformFixtureDataFn;
         let loadFixturesOptions = {
-            'log': logging ? null : _.noop
+            'log': logging ? null : SequelizeMocking.noop
         };
 
-        if (_.isFunction(transformFixtureDataFn)) {
+        if (typeof transformFixtureDataFn === 'function') {
             loadFixturesOptions.transformFixtureDataFn = transformFixtureDataFn;
         }
 

--- a/lib/sequelize-mocking.js
+++ b/lib/sequelize-mocking.js
@@ -11,8 +11,8 @@
 'use strict';
 
 // Imports
+const _ = require('lodash');
 const Sequelize = require('sequelize');
-const _ = Sequelize.Utils._;
 const sequelizeFixtures = require('sequelize-fixtures');
 
 // Constants and variables

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,59 +4,59 @@
   "dependencies": {
     "sequelize-fixtures": {
       "version": "0.6.0",
-      "from": "sequelize-fixtures@0.6.0",
+      "from": "https://registry.npmjs.org/sequelize-fixtures/-/sequelize-fixtures-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/sequelize-fixtures/-/sequelize-fixtures-0.6.0.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "from": "bluebird@>=2.4.2 <3.0.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
         },
         "glob": {
           "version": "7.0.6",
-          "from": "glob@>=7.0.5 <7.1.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
             },
             "inflight": {
               "version": "1.0.6",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "minimatch": {
               "version": "3.0.4",
-              "from": "minimatch@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "from": "brace-expansion@>=1.1.7 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "from": "balanced-match@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -65,67 +65,67 @@
             },
             "once": {
               "version": "1.4.0",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
             }
           }
         },
         "js-yaml": {
           "version": "2.1.3",
-          "from": "js-yaml@>=2.1.0 <2.2.0",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.1.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
         }
       }
     },
     "sqlite3": {
       "version": "3.1.8",
-      "from": "sqlite3@3.1.8",
+      "from": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.8.tgz",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.8.tgz",
       "dependencies": {
         "nan": {
           "version": "2.4.0",
-          "from": "nan@>=2.4.0 <2.5.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
         },
         "node-pre-gyp": {
@@ -504,11 +504,6 @@
                   "from": "hawk@~3.1.3",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "hoek@2.x.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
                     "boom": {
                       "version": "2.10.1",
                       "from": "boom@2.x.x",
@@ -518,6 +513,11 @@
                       "version": "2.0.5",
                       "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@2.x.x",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
@@ -573,40 +573,45 @@
                           "from": "assert-plus@^1.0.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                         },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.0",
+                          "from": "bcrypt-pbkdf@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                          "optional": true
+                        },
                         "dashdash": {
                           "version": "1.14.0",
                           "from": "dashdash@^1.12.0",
                           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "from": "ecc-jsbn@~0.1.1",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "optional": true
                         },
                         "getpass": {
                           "version": "0.1.6",
                           "from": "getpass@^0.1.1",
                           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                         },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "from": "jodid25519@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "optional": true
+                        },
                         "jsbn": {
                           "version": "0.1.0",
                           "from": "jsbn@~0.1.0",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                          "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.3",
                           "from": "tweetnacl@~0.14.0",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2",
-                          "from": "jodid25519@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "from": "ecc-jsbn@~0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                        },
-                        "bcrypt-pbkdf": {
-                          "version": "1.0.0",
-                          "from": "bcrypt-pbkdf@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                          "optional": true
                         }
                       }
                     }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "homepage": "https://github.com/rochejul/sequelize-mocking#readme",
   "dependencies": {
     "sequelize-fixtures": "0.6.0",
-    "sqlite3": "3.1.8"
+    "sqlite3": "3.1.8",
+    "lodash": "4.17.4"
   },
   "engines": {
     "node": ">=4.0.0",
@@ -50,7 +51,6 @@
   "devDependencies": {
     "chai": "4.0.2",
     "eslint": "4.2.0",
-    "lodash": "4.17.4",
     "mocha": "3.4.2",
     "mysql2": "1.3.5",
     "npmversion": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
   },
   "homepage": "https://github.com/rochejul/sequelize-mocking#readme",
   "dependencies": {
+    "lodash": "4.17.4",
     "sequelize-fixtures": "0.6.0",
-    "sqlite3": "3.1.8",
-    "lodash": "4.17.4"
+    "sqlite3": "3.1.8"
   },
   "engines": {
     "node": ">=4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "homepage": "https://github.com/rochejul/sequelize-mocking#readme",
   "dependencies": {
-    "lodash": "4.17.4",
     "sequelize-fixtures": "0.6.0",
     "sqlite3": "3.1.8"
   },
@@ -51,6 +50,7 @@
   "devDependencies": {
     "chai": "4.0.2",
     "eslint": "4.2.0",
+    "lodash": "4.17.4",
     "mocha": "3.4.2",
     "mysql2": "1.3.5",
     "npmversion": "1.3.3",

--- a/test/sequelize-mockingSpec.js
+++ b/test/sequelize-mockingSpec.js
@@ -789,7 +789,7 @@ describe('SequelizeMocking - ', function () {
                         },
                         {
                             'encoding': 'utf8',
-                            'log': _.noop
+                            'log': SequelizeMocking.noop
                         }
                     ]);
                 });
@@ -842,7 +842,7 @@ describe('SequelizeMocking - ', function () {
                         },
                         {
                             'encoding': 'utf8',
-                            'log': _.noop,
+                            'log': SequelizeMocking.noop,
                             'transformFixtureDataFn': transformFixtureDataFn
                         }
                     ]);

--- a/test/sequelize-mockingSpec.js
+++ b/test/sequelize-mockingSpec.js
@@ -789,7 +789,7 @@ describe('SequelizeMocking - ', function () {
                         },
                         {
                             'encoding': 'utf8',
-                            'log': Sequelize.Utils._.noop
+                            'log': _.noop
                         }
                     ]);
                 });
@@ -842,7 +842,7 @@ describe('SequelizeMocking - ', function () {
                         },
                         {
                             'encoding': 'utf8',
-                            'log': Sequelize.Utils._.noop,
+                            'log': _.noop,
                             'transformFixtureDataFn': transformFixtureDataFn
                         }
                     ]);


### PR DESCRIPTION
With sequelize 4.8.0 (and greater) : Sequelize.Utils._ is undefined