### PR TITLE
Add afterhook name

### DIFF
--- a/lib/sequelize-mocking.js
+++ b/lib/sequelize-mocking.js
@@ -18,6 +18,7 @@ const sequelizeFixtures = require('sequelize-fixtures');
 // Constants and variables
 const FAKE_DATABASE_NAME = 'test-database';
 const AFTER_DEFINE_EVENT = 'afterDefine';
+const AFTER_DEFINE_EVENT_NAME = 'sequelizeMockAfterDefine';
 const SQLITE_SEQUELIZE_OPTIONS = {
     'dialect': 'sqlite',
     'storage': ':memory:'
@@ -132,7 +133,7 @@ class SequelizeMocking {
     static hookNewModel(originalSequelize, mockedSequelize, options) {
         let logging = !options || options.logging;
 
-        originalSequelize.addHook(AFTER_DEFINE_EVENT, function (newModel) {
+        originalSequelize.addHook(AFTER_DEFINE_EVENT, AFTER_DEFINE_EVENT_NAME, function (newModel) {
             SequelizeMocking
                 .modifyModelReference(
                     mockedSequelize,
@@ -263,7 +264,7 @@ class SequelizeMocking {
      */
     static unhookNewModel(mockedSequelize) {
         if (mockedSequelize.__originalSequelize) {
-            mockedSequelize.__originalSequelize.removeHook(AFTER_DEFINE_EVENT);
+            mockedSequelize.__originalSequelize.removeHook(AFTER_DEFINE_EVENT, AFTER_DEFINE_EVENT_NAME);
         }
     }
 }

--- a/test/sequelize-mockingSpec.js
+++ b/test/sequelize-mockingSpec.js
@@ -562,7 +562,7 @@ describe('SequelizeMocking - ', function () {
             SequelizeMocking.hookNewModel(sequelizeInstance, mockedSequelizeInstance);
             expect(spy.called).to.be.true;
             expect(spy.calledOnce).to.be.true;
-            expect(spy.calledWith('afterDefine', sinon.match.func)).to.be.true;
+            expect(spy.calledWith('afterDefine', 'sequelizeMockAfterDefine', sinon.match.func)).to.be.true;
         });
 
         it('should call "copyModel" when a new model is added', function () {


### PR DESCRIPTION
When running consecutive tests, the hooks are not removed and models creation in database cumulates.

see https://github.com/sequelize/sequelize/blob/master/lib/hooks.js#L184 
and http://docs.sequelizejs.com/manual/tutorial/hooks.html#removing-hooks